### PR TITLE
Fix loops using implicit global i

### DIFF
--- a/backend/bot/controllers/commands.contoller.js
+++ b/backend/bot/controllers/commands.contoller.js
@@ -194,7 +194,7 @@ async function getRandomImage(guildId) {
  */
 async function deleteUserAccountImages(imageLocationReferences) {
   try {
-    for (i = 0; i < imageLocationReferences.length; i++) {
+    for (let i = 0; i < imageLocationReferences.length; i++) {
       //This refers to path saved in db which references /server directory refrence looks like --> /uploads/guildId/filename
       let currentUrl = imageLocationReferences[i].image_url;
       //Since all media (paths) are based in the server directory we need to go up a directories

--- a/backend/server/controllers/media.controller.js
+++ b/backend/server/controllers/media.controller.js
@@ -289,7 +289,7 @@ async function deleteUserAccountImages(imageLocationReferences) {
     if (imageLocationReferences.length <= 0) return;
 
     //TODO: FIX IMAGE REFERENCES THERE ARE TOO MANY OF THEM...
-    for (i = 0; i < imageLocationReferences.length; i++) {
+    for (let i = 0; i < imageLocationReferences.length; i++) {
    
       let currentUrl = imageLocationReferences[i].image_url;
 


### PR DESCRIPTION
## Summary
- use `let` for loop indexes in media and command controllers

## Testing
- `npm test --silent` *(fails: `ng` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68706a28b18c8326b3461544996ab8a3