### PR TITLE
Create file mover helper and use in controllers

### DIFF
--- a/backend/bot/controllers/commands.contoller.js
+++ b/backend/bot/controllers/commands.contoller.js
@@ -4,7 +4,7 @@ const { Connection } = require("../../server/helpers/mongoConnection.helper");
 //Controller object
 let controller = {};
 //const db_controller = require("../../server/controllers/db.controller");
-const fs = require("fs-extra");
+const { moveFilesToDeletedMedia } = require("../../server/helpers/fileMover");
 //dayjs instance
 const dayjs = require("dayjs");
 const { Client, Intents } = require("discord.js");
@@ -194,27 +194,8 @@ async function getRandomImage(guildId) {
  */
 async function deleteUserAccountImages(imageLocationReferences) {
   try {
-    for (i = 0; i < imageLocationReferences.length; i++) {
-      //This refers to path saved in db which references /server directory refrence looks like --> /uploads/guildId/filename
-      let currentUrl = imageLocationReferences[i].image_url;
-      //Since all media (paths) are based in the server directory we need to go up a directories
-      const serverDir = `../server`;
-      //Current (relative) location of file to be moved
-      const currentLoc = `${serverDir}${currentUrl}`;
-      //The subdirectory of 'delete-media' directory to store deleted image.
-      const subDir = currentUrl.split("/")[2];
-      //Filename of file to move from live directory to 'delete-media' directory.
-      const fileName = currentUrl.split("/")[3];
-      //File to be moved, final directory destination included.
-      //MOD:Changing from `./deleted-media/${subDir}/${fileName}`; --> `../deleted-media/${subDir}/${fileName}`;
-      const deletedDirLoc = `../server/deleted-media/${subDir}`;
-      const deletedFileLoc = `${deletedDirLoc}/${fileName}`;
-      //Ensure directory exists
-      await fs.ensureDir(deletedDirLoc);
-      //move file from live directory to non-live directory
-      await fs.move(currentLoc, deletedFileLoc);
-      //await fs.move(currentLoc, deletedFileLoc, { overwrite: true });
-    }
+    const paths = imageLocationReferences.map((ref) => ref.image_url);
+    await moveFilesToDeletedMedia(paths);
     return;
   } catch (err) {
     console.log(err);

--- a/backend/server/controllers/media.controller.js
+++ b/backend/server/controllers/media.controller.js
@@ -6,6 +6,7 @@ const util = require("util");
 const multer = require("multer");
 const path = require("path");
 const fse = require("fs-extra");
+const { moveFilesToDeletedMedia } = require("../helpers/fileMover");
 let dayjs = require("dayjs");
 
 const sharp = require("sharp");
@@ -133,18 +134,10 @@ async function deleteImage(imageData) {
     //The discord id is in the image_URL, it's the digits between slashes (the number before the final slash and name of image);
     //Since our image_URL is structured 'uploads/discordID/imageName, we will simply extact the discord id from this string.
     imageData.discord_id = imageData.image_url.split("/")[2];
-    //Current (relative) location of file to be moved
-    const currentLoc = `.${imageData.image_url}`;
-    //The subdirectory of 'delete-media' directory to store deleted image.
-    const subDir = imageData.image_url.split("/")[2];
-    //Filename of file to move from live directory to 'delete-media' directory.
-    const fileName = imageData.image_url.split("/")[3];
-    //File to be moved, final directory destination included.
-    const deletedFileLoc = `./deleted-media/${subDir}/${fileName}`;
-    //Ensure directory exists
-    await fse.ensureDir(`./deleted-media/${subDir}`);
-    //move file from live directory to non-live directory
-    await fse.move(currentLoc, deletedFileLoc, { overwrite: true });
+
+    //Move file to deleted-media directory
+    await moveFilesToDeletedMedia([imageData.image_url]);
+
     //Remove image from database
     let deletedImage = await db_controller.deleteImage(imageData);
 
@@ -288,31 +281,9 @@ async function deleteUserAccountImages(imageLocationReferences) {
   try {
     if (imageLocationReferences.length <= 0) return;
 
-    //TODO: FIX IMAGE REFERENCES THERE ARE TOO MANY OF THEM...
-    for (i = 0; i < imageLocationReferences.length; i++) {
-   
-      let currentUrl = imageLocationReferences[i].image_url;
-
-
-      //Current (relative) location of file to be moved
-      const currentLoc = `.${currentUrl}`;
-      //The subdirectory of 'delete-media' directory to store deleted image.
-      const subDir = currentUrl.split("/")[2];
-      //Filename of file to move from live directory to 'delete-media' directory.
-      const fileName = currentUrl.split("/")[3];
-      //File to be moved, final directory destination included.
-      //MOD:Changing from `./deleted-media/${subDir}/${fileName}`; --> `../deleted-media/${subDir}/${fileName}`;
-      //const deletedDirLoc = `../deleted-media/${subDir}`;
-      //const deletedDirLoc = `./deleted-media/${subDir}`;
-      //const deletedFileLoc = `${deletedDirLoc}/${fileName}`;
-      //File to be moved, final directory destination included.
-      const deletedFileLoc = `./deleted-media/${subDir}/${fileName}`;
-      //Ensure directory exists
-      await fse.ensureDir(`./deleted-media/${subDir}`);
-      //move file from live directory to non-live directory
-      await fse.move(currentLoc, deletedFileLoc);
-      //await fse.move(currentLoc, deletedFileLoc, { overwrite: true });
-    }
+    //Move all files to deleted-media directory
+    const paths = imageLocationReferences.map((ref) => ref.image_url);
+    await moveFilesToDeletedMedia(paths);
     return;
   } catch (err) {
     console.log(err);

--- a/backend/server/helpers/fileMover.js
+++ b/backend/server/helpers/fileMover.js
@@ -1,0 +1,36 @@
+const path = require('path');
+const fse = require('fs-extra');
+
+/**
+ * Move image paths to the deleted-media directory.
+ *
+ * @param {Array<string|{image_url:string}>} imagePaths Array of paths or objects containing image_url
+ * @param {string} [baseDir] Base directory containing uploads and deleted-media folders
+ */
+async function moveFilesToDeletedMedia(imagePaths, baseDir = path.join(__dirname, '..')) {
+  if (!Array.isArray(imagePaths)) {
+    throw new Error('imagePaths must be an array');
+  }
+
+  for (const ref of imagePaths) {
+    const imagePath = typeof ref === 'string' ? ref : ref.image_url;
+    if (!imagePath) continue;
+
+    const relativePath = imagePath.replace(/^\/+/, '');
+    const parts = relativePath.split(/[\\/]/);
+    if (parts.length < 3) continue;
+    const subDir = parts[1];
+    const fileName = parts.slice(2).join('/');
+
+    const src = path.join(baseDir, relativePath);
+    const destDir = path.join(baseDir, 'deleted-media', subDir);
+    const dest = path.join(destDir, fileName);
+
+    await fse.ensureDir(destDir);
+    await fse.move(src, dest, { overwrite: true });
+  }
+}
+
+module.exports = {
+  moveFilesToDeletedMedia,
+};

--- a/backend/server/helpers/fileMover.test.js
+++ b/backend/server/helpers/fileMover.test.js
@@ -1,0 +1,26 @@
+const test = require('node:test');
+const assert = require('assert');
+const path = require('path');
+const os = require('os');
+const fse = require('fs-extra');
+
+const { moveFilesToDeletedMedia } = require('./fileMover');
+
+test('moves files from uploads to deleted-media', async () => {
+  const tmpDir = await fse.mkdtemp(path.join(os.tmpdir(), 'fileMover-'));
+  const uploadsDir = path.join(tmpDir, 'uploads', 'guild1');
+  await fse.ensureDir(uploadsDir);
+  const srcFile = path.join(uploadsDir, 'test.txt');
+  await fse.writeFile(srcFile, 'hello');
+
+  await moveFilesToDeletedMedia(['/uploads/guild1/test.txt'], tmpDir);
+
+  const destFile = path.join(tmpDir, 'deleted-media', 'guild1', 'test.txt');
+  const srcExists = await fse.pathExists(srcFile);
+  const destExists = await fse.pathExists(destFile);
+
+  assert.strictEqual(srcExists, false);
+  assert.strictEqual(destExists, true);
+
+  await fse.remove(tmpDir);
+});


### PR DESCRIPTION
## Summary
- implement `moveFilesToDeletedMedia` helper
- create unit test for the helper
- replace deletion logic in server and bot controllers with helper

## Testing
- `node --test backend/server/helpers/fileMover.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68706a2a81b08326907f7bad2e0424ee